### PR TITLE
chore(deps): consolidate Snyk security upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 gtts==2.3.2
 pandas==1.5.3
+requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Consolidates the six outstanding Snyk security PRs into a single `requirements.txt` change, taking the highest proposed version wherever they overlap.

| Package | Now | Supersedes |
|---|---|---|
| requests | **>=2.32.4** | #1 (2.32.0), #4 (2.32.4) |
| urllib3 | **>=2.6.3** | #2 (2.2.2), #5 (2.5.0), #6 (2.6.3) |
| zipp | **>=3.19.1** | #3 |

Verified the union resolves cleanly via `pip install --dry-run` (requests 2.34.2, urllib3 2.7.0, zipp 4.1.0; compatible with gtts).

Closes #1
Closes #2
Closes #3
Closes #4
Closes #5
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)